### PR TITLE
fix(test): replace bare delay with poll in AutoStart_starts_timer_immediately

### DIFF
--- a/Tharga.Toolkit.Standard.Tests/ManagedTimerTests.cs
+++ b/Tharga.Toolkit.Standard.Tests/ManagedTimerTests.cs
@@ -227,8 +227,12 @@ public class ManagedTimerTests
     {
         var timer = new ManagedTimer(TimeSpan.FromMilliseconds(500), _ => Task.CompletedTask, autoStart: true);
 
-        // Give the async task a moment to start
-        await Task.Delay(50);
+        // Poll for state transition — bare delays are flaky on busy CI runners.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (timer.State == ManagedTimer.TimerState.Stopped && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
         timer.State.Should().NotBe(ManagedTimer.TimerState.Stopped);
 
         timer.Stop();


### PR DESCRIPTION
## Summary
`AutoStart_starts_timer_immediately` failed on the master build after PR #41 — `Task.Delay(50)` was not enough to let the timer transition out of `Stopped` on a busy Linux runner.

Replaces the bare delay with a 2-second polling loop. Locally exits in one iteration; on CI it tolerates scheduling jitter.

## Test plan
- [x] Test passes locally
- [ ] CI green